### PR TITLE
upgrade to null safe

### DIFF
--- a/lib/src/date_time.dart
+++ b/lib/src/date_time.dart
@@ -20,8 +20,6 @@ class TZDateTime implements DateTime {
 
   /// Converts a [_localDateTime] into a correct [DateTime].
   static DateTime _utcFromLocalDateTime(DateTime local, Location location) {
-    assert(local != null, "DateTime argument must not be null");
-    assert(location != null, "Location argument must not be null");
     var unix = local.millisecondsSinceEpoch;
     var tzData = location.lookupTimeZone(unix);
     if (tzData.timeZone.offset != 0) {
@@ -210,13 +208,10 @@ class TZDateTime implements DateTime {
                 ? TimeZone.UTC
                 : location.timeZone(other.millisecondsSinceEpoch));
 
-  TZDateTime._(DateTime native, Location location, TimeZone timeZone)
-      : assert(location != null, "Location argument must not be null"),
-        _native = native,
+  TZDateTime._(DateTime native, this.location, this.timeZone)
+      : _native = native,
         _localDateTime =
-            _isUtc(location) ? native : native.add(_timeZoneOffset(timeZone)),
-        location = location,
-        timeZone = timeZone;
+            _isUtc(location) ? native : native.add(_timeZoneOffset(timeZone));
 
   /// Constructs a new [TZDateTime] instance based on [formattedString].
   ///

--- a/lib/src/env.dart
+++ b/lib/src/env.dart
@@ -16,8 +16,8 @@ const String tzDataDefaultFilename = 'latest.tzf';
 
 final Location _UTC = Location('UTC', [minTime], [0], [TimeZone.UTC]);
 
-LocationDatabase _database;
-Location _local;
+final _database = LocationDatabase();
+late Location _local;
 
 /// Global TimeZone database
 LocationDatabase get timeZoneDatabase => _database;
@@ -51,13 +51,13 @@ void setLocalLocation(Location location) {
 
 /// Initialize Time zone database.
 void initializeDatabase(List<int> rawData) {
-  _database ??= LocationDatabase();
+  _database.clear();
 
   for (final l in tzdbDeserialize(rawData)) {
     _database.add(l);
   }
 
-  _local ??= _UTC;
+  _local = _UTC;
 }
 
 /// Initialize Time Zone database from [encodedDatabase].

--- a/lib/src/location.dart
+++ b/lib/src/location.dart
@@ -47,7 +47,7 @@ class Location {
   static final int _cacheNow = DateTime.now().millisecondsSinceEpoch;
   int _cacheStart = 0;
   int _cacheEnd = 0;
-  TimeZone _cacheZone;
+  late TimeZone _cacheZone;
 
   Location(this.name, this.transitionAt, this.transitionZone, this.zones) {
     // Fill in the cache with information about right now,

--- a/lib/src/location_database.dart
+++ b/lib/src/location_database.dart
@@ -35,4 +35,7 @@ class LocationDatabase {
     }
     return loc;
   }
+
+  /// Clears the database of all [Location] entries.
+  void clear() => _locations.clear();
 }

--- a/lib/src/tzdata/zone_tab.dart
+++ b/lib/src/tzdata/zone_tab.dart
@@ -28,16 +28,18 @@ class LocationDescription {
     final name = parts[2];
     final comments = parts.length > 3 ? parts[3] : '';
 
-    final match = _geoLocationRe.firstMatch(parts[1]);
+    final match = _geoLocationRe.firstMatch(parts[1])!;
     final latSign = match.group(1) == '+' ? 1 : -1;
-    final latDeg = int.parse(match.group(2));
-    final latMinutes = int.parse(match.group(3));
-    final latSeconds = match.group(4) != null ? int.parse(match.group(4)) : 0;
+    final latDeg = int.parse(match.group(2)!);
+    final latMinutes = int.parse(match.group(3)!);
+    final latSecondsRaw = match.group(4);
+    final latSeconds = latSecondsRaw != null ? int.parse(latSecondsRaw) : 0;
 
     final longSign = match.group(5) == '+' ? 1 : -1;
-    final longDeg = int.parse(match.group(6));
-    final longMinutes = int.parse(match.group(7));
-    final longSeconds = match.group(8) != null ? int.parse(match.group(8)) : 0;
+    final longDeg = int.parse(match.group(6)!);
+    final longMinutes = int.parse(match.group(7)!);
+    final longSecondsRaw = match.group(8);
+    final longSeconds = longSecondsRaw != null ? int.parse(longSecondsRaw) : 0;
 
     final latitude = latSign * (latDeg + (latMinutes + (latSeconds / 60)) / 60);
     final longitude =

--- a/lib/standalone.dart
+++ b/lib/standalone.dart
@@ -15,11 +15,11 @@
 library timezone.standalone;
 
 import 'dart:async';
-import 'dart:isolate';
 import 'package:path/path.dart' as p;
-import 'package:timezone/timezone.dart';
 import 'package:node_io/node_io.dart';
+import 'package:timezone/timezone.dart';
 export 'package:timezone/timezone.dart'
+
     show
         getLocation,
         setLocalLocation,
@@ -48,7 +48,7 @@ Future<List<int>> _loadAsBytes(String path) async {
 ///   final detroitNow = new TZDateTime.now(detroit);
 /// });
 /// ```
-Future<void> initializeTimeZone([String path]) {
+Future<void> initializeTimeZone([String? path]) {
   path ??= tzDataDefaultPath;
   return _loadAsBytes(path).then((rawData) {
     initializeDatabase(rawData);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,10 +6,10 @@ authors:
 description: Time zone database and time zone aware DateTime.
 homepage: https://github.com/srawlins/timezone
 environment:
-  sdk: '>=2.1.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dependencies:
-  path: '^1.3.0'
-  node_interop: ^2.0.2
+  path: '^1.8.0'
+  node_io: ^2.1.0
 dev_dependencies:
   args: any
   glob: any

--- a/test/datetime_test.dart
+++ b/test/datetime_test.dart
@@ -20,10 +20,6 @@ Future<void> main() async {
       expect(t.toString(), equals('2010-01-01 00:00:00.000-0800'));
     });
 
-    test('Default, null argument', () {
-      expect(() => TZDateTime(null, 2010), throwsA(isA<AssertionError>()));
-    });
-
     test('from DateTime', () {
       final utcTime = DateTime.utc(2010, 1, 2, 3, 4, 5, 6, 7);
       final t = TZDateTime.from(utcTime, newYork);

--- a/test/zicfile_test.dart
+++ b/test/zicfile_test.dart
@@ -16,7 +16,7 @@ void main() {
   test('Read US/Eastern 2014h tzfile', () async {
     var packageUri = Uri(scheme: 'package', path: 'timezone/timezone.dart');
     var packagePath = p
-        .dirname(p.dirname((await Isolate.resolvePackageUri(packageUri)).path));
+        .dirname(p.dirname((await Isolate.resolvePackageUri(packageUri))!.path));
     var locationDir = p.join(packagePath, 'test');
     var rawData =
         await File(p.join(locationDir, 'data/US/Eastern')).readAsBytes();

--- a/test/zone_tab_test.dart
+++ b/test/zone_tab_test.dart
@@ -12,7 +12,7 @@ void main() {
   test('Read zone1970.tab file', () async {
     var packageUri = Uri(scheme: 'package', path: 'timezone/timezone.dart');
     var packagePath = p
-        .dirname(p.dirname((await Isolate.resolvePackageUri(packageUri)).path));
+        .dirname(p.dirname((await Isolate.resolvePackageUri(packageUri))!.path));
     var locationDir = p.join(packagePath, 'test');
     var rawData =
         await File(p.join(locationDir, 'data/zone1970.tab')).readAsString();

--- a/tool/get.dart
+++ b/tool/get.dart
@@ -21,6 +21,7 @@ import 'package:args/args.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 import 'package:glob/glob.dart';
+import 'package:glob/list_local_fs.dart';
 
 import 'package:timezone/tzdata.dart' as tzfile;
 import 'package:timezone/timezone.dart';
@@ -69,7 +70,7 @@ Future<String> downloadTzData(String version, String dest) async {
       await sink.close();
     }
   } finally {
-    await client.close();
+    client.close();
   }
   return outPath;
 }


### PR DESCRIPTION
Updates for null safety

I swapped out node_interop library for node_io because the most recent version seems to have split into different packages, and the file stuff is in node_io ([github](https://github.com/pulyaevskiy/node-interop/tree/master/node_io), [pub.dev](https://pub.dev/packages/node_io))

Otherwise I applied the changes I found in srawlins/timezone